### PR TITLE
Doesn't fail if pkglist is empty

### DIFF
--- a/pkgbuild.sh
+++ b/pkgbuild.sh
@@ -38,6 +38,8 @@ for pkgkey in ${pkgkeys[@]}; do
 done
 
 # Build outdated packages.
-aur sync -d $pkgrepo --root "${HOME}/bin" -n ${pkglist[@]}
+if (( ${#pkglist[@]} )); then
+  aur sync -d $pkgrepo --root "${HOME}/bin" -n ${pkglist[@]}
+fi
 
 { set +ex; } 2>/dev/null


### PR DESCRIPTION
Fix travis-ci build fail when the `pkglist` is empty, default behavior at master branch.