### PR TITLE
Permit to use a custom makepkg.conf for package setups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ before_install:
 install:
   - docker cp pkgrepository.sh aurci:/home/pkguser
   - docker cp pkgbuild.sh aurci:/home/pkguser
+  - if [ -f makepkg.conf ]; then
+      docker cp makepkg.conf aurci:/home/pkguser/.makepkg.conf;
+    fi
 before_script:
   - docker cp pkglist aurci:/home/pkguser
   - docker cp pkgkeys aurci:/home/pkguser
 script:
-  - docker exec aurci bash pkgrepository.sh $TRAVIS_REPO_SLUG $TRAVIS_TAG
+  - docker exec aurci bash pkgrepository.sh $TRAVIS_REPO_SLUG $TRAVIS_TAG $USER
   - docker exec aurci bash pkgbuild.sh $TRAVIS_REPO_SLUG $TRAVIS_BUILD_ID
 before_deploy:
   - docker cp aurci:/home/pkguser/bin $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - docker cp pkglist aurci:/home/pkguser
   - docker cp pkgkeys aurci:/home/pkguser
 script:
-  - docker exec aurci bash pkgrepository.sh $TRAVIS_REPO_SLUG $TRAVIS_TAG $USER
+  - docker exec aurci bash pkgrepository.sh $TRAVIS_REPO_SLUG $TRAVIS_TAG
   - docker exec aurci bash pkgbuild.sh $TRAVIS_REPO_SLUG $TRAVIS_BUILD_ID
 before_deploy:
   - docker cp aurci:/home/pkguser/bin $TRAVIS_TAG

--- a/makepkg.conf
+++ b/makepkg.conf
@@ -1,1 +1,0 @@
-PACKAGER="AURCI <travis_bot@email.invalid>"

--- a/makepkg.conf
+++ b/makepkg.conf
@@ -1,0 +1,1 @@
+PACKAGER="AURCI <travis_bot@email.invalid>"

--- a/pkgbuild.sh
+++ b/pkgbuild.sh
@@ -3,11 +3,10 @@
 set -ex
 
 # Environment variables.
-if [ ! -f "/home/pkguser/.makepkg.conf" ]; then
-  echo "No makepkg.conf found, exporting PACKAGER variable."
-  export PACKAGER="${1/\// } <${2}@${3}.build.id>"
-else
-  echo "/home/pkguser/.makepkg.conf found, ensure that the PACKAGER variable is set there."
+makepkg_conf="/home/pkguser/.makepkg.conf"
+if [ ! -f ${makepkg_conf} ] || ! $(grep -Fxq "PACKAGER" ${makepkg_conf}) ; then
+# echo "No makepkg.conf or no PACKAGER variable found: exporting it..."
+  export PACKAGER="${1/\// } <${2}@travis.build.id>"
 fi
 export AURDEST="$(pwd)/src"
 

--- a/pkgbuild.sh
+++ b/pkgbuild.sh
@@ -3,7 +3,12 @@
 set -ex
 
 # Environment variables.
-export PACKAGER="https://travis-ci.org/${1}/builds/${2}"
+if [ ! -f "/home/pkguser/.makepkg.conf" ]; then
+  echo "No makepkg.conf found, exporting PACKAGER variable."
+  export PACKAGER="${1/\// } <${2}@${3}.build.id>"
+else
+  echo "/home/pkguser/.makepkg.conf found, ensure that the PACKAGER variable is set there."
+fi
 export AURDEST="$(pwd)/src"
 
 # Variables declaration.


### PR DESCRIPTION
Added an optional `.makepkg.conf` setting file in `$HOME` for custom package settings,
like the `PACKAGER` variable and the like.

It seems after some tests that after copying the file the PACKAGER variable in `pkgbuild.sh` overwrite the one in the former, so I used an if/else condition to avoid it, that also warns the user in the build log about what's going on.
See also #18.

Sorry for the second commit, but maybe it's OK to have an example on the git history :-P